### PR TITLE
Add intelliJ ignores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,7 @@ build/
 # Omit committing pubspec.lock for library packages; see
 # https://dart.dev/guides/libraries/private-files#pubspeclock.
 pubspec.lock
+
+# IntelliJ related
+.idea/
+*.iml


### PR DESCRIPTION
@jxstxn1 Want to add vscodes?

Just asked ChatGPT about it:
<img width="799" alt="image" src="https://user-images.githubusercontent.com/34774539/205495403-2b1470a3-144a-4190-ab46-e12c432830cc.png">

Is it correct for vscode too? Except that it is not a flutter project but a dart project.