### PR TITLE
Improve error Handling

### DIFF
--- a/lib/src/docker/create_image.dart
+++ b/lib/src/docker/create_image.dart
@@ -10,8 +10,6 @@ void createDockerImage() {
     'docker',
     ['build', '-t', '${mainProject!.name}:dev', '.'],
     workingDirectory: repository.root.directory('server'),
-  );
-  print(
-    green('Created image ${mainProject!.name}:dev'),
+    successMessage: 'Created image ${mainProject!.name}:dev',
   );
 }

--- a/lib/src/docker/run_image.dart
+++ b/lib/src/docker/run_image.dart
@@ -19,6 +19,6 @@ void runImage({String? port}) {
       '${mainProject!.name}:dev',
     ],
     workingDirectory: repository.root.directory('server'),
+    successMessage: 'App is running on http://localhost:$publicPort',
   );
-  print(green('App is running on http://localhost:$publicPort'));
 }

--- a/lib/src/docker/stop_image.dart
+++ b/lib/src/docker/stop_image.dart
@@ -8,6 +8,6 @@ void stopImage({bool silent = false}) {
     ['kill', mainProject!.name],
     workingDirectory: repository.root.directory('server'),
     silent: silent,
+    successMessage: 'Stopped app: ${mainProject!.name}:dev',
   );
-  if (!silent) print(green('Stopped app: ${mainProject!.name}:dev'));
 }

--- a/lib/src/util/command_runner.dart
+++ b/lib/src/util/command_runner.dart
@@ -1,5 +1,4 @@
 import 'package:dcli/dcli.dart' as dcli;
-import 'package:dockerize_sidekick_plugin/dockerize_sidekick_plugin.dart';
 import 'package:sidekick_core/sidekick_core.dart';
 
 /// Internal Command runner which only prints the output if there is an error
@@ -9,6 +8,7 @@ void commandRunner(
   required Directory workingDirectory,
   dcli.Progress? progress,
   bool silent = false,
+  required String successMessage,
 }) {
   final processProgress = progress ??
       dcli.Progress(
@@ -23,10 +23,9 @@ void commandRunner(
       workingDirectory: workingDirectory.path,
       progress: processProgress,
     );
+    if (!silent) print(green(successMessage));
   } catch (e) {
-    if (!silent) {
-      print(processProgress.lines.join('\n'));
-      print(printUsage(cliName));
-    }
+    print(processProgress.lines.join('\n'));
+    exit(1);
   }
 }


### PR DESCRIPTION
Improved Error Handling by:
 - not printing success if the command fails
 - not printing always the usage 
 - printing error also if the command_runner is silenced
 - exiting if an error occurs

Addressing #28 