### PR TITLE
Run in foreground

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,10 +44,12 @@ You can customize the build process in the commands/docker/build_command.dart fi
 ```
 
 This will run your app and makes it accessible at `localhost:8000`.
-You can detach from your running container with `Ctrl + P + Q` or `Ctrl + C`.
-Afterwards you can kill the container with `<<your_cli>> docker stop`.
+With the `--background` flag you can run the container in the background.
 With the `-b, --build` flag you can execute the build command before running the container.
 With the `-p, --port` flag you can specify the port on which the app is accessible.
+
+You can detach from your running container with `Ctrl + P + Q` or `Ctrl + C`.
+Afterwards you can kill the container with `<<your_cli>> docker stop`.
 
 #### Stop the container
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ You can customize the build process in the commands/docker/build_command.dart fi
 ```
 
 This will run your app and makes it accessible at `localhost:8000`.
+You can detach from your running container with `Ctrl + P + Q` or `Ctrl + C`.
+Afterwards you can kill the container with `<<your_cli>> docker stop`.
 With the `-b, --build` flag you can execute the build command before running the container.
 With the `-p, --port` flag you can specify the port on which the app is accessible.
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ You can customize the build process in the commands/docker/build_command.dart fi
 <<your_cli>> docker run
 ```
 
-This will run your app and makes it accessible at `localhost:8080`.
+This will run your app and makes it accessible at `localhost:8000`.
 With the `-b, --build` flag you can execute the build command before running the container.
 With the `-p, --port` flag you can specify the port on which the app is accessible.
 

--- a/lib/src/docker/run_image.dart
+++ b/lib/src/docker/run_image.dart
@@ -1,16 +1,16 @@
+import 'package:dcli/dcli.dart' as dcli;
 import 'package:dockerize_sidekick_plugin/dockerize_sidekick_plugin.dart';
-import 'package:dockerize_sidekick_plugin/src/util/command_runner.dart';
 import 'package:sidekick_core/sidekick_core.dart';
 
 /// Starting the docker image
 void runImage({String? port}) {
   final String publicPort = port ?? '8000';
   stopImage(silent: true);
-  commandRunner(
+  dcli.startFromArgs(
     'docker',
     [
       'run',
-      '-d',
+      '-it',
       '--rm',
       '-p',
       '$publicPort:8080',
@@ -18,7 +18,7 @@ void runImage({String? port}) {
       mainProject!.name,
       '${mainProject!.name}:dev',
     ],
-    workingDirectory: repository.root.directory('server'),
-    successMessage: 'App is running on http://localhost:$publicPort',
+    terminal: true,
+    workingDirectory: repository.root.directory('server').path,
   );
 }

--- a/lib/src/docker/run_image.dart
+++ b/lib/src/docker/run_image.dart
@@ -11,6 +11,8 @@ void runImage({String? port}) {
     [
       'run',
       '-it',
+      '--sig-proxy=false',
+      '--detach-keys=ctrl-c',
       '--rm',
       '-p',
       '$publicPort:$publicPort',

--- a/lib/src/docker/run_image.dart
+++ b/lib/src/docker/run_image.dart
@@ -3,16 +3,20 @@ import 'package:dockerize_sidekick_plugin/dockerize_sidekick_plugin.dart';
 import 'package:sidekick_core/sidekick_core.dart';
 
 /// Starting the docker image
-void runImage({String? port}) {
+void runImage({String? port, bool background = false}) {
   final String publicPort = port ?? '8000';
   stopImage(silent: true);
   dcli.startFromArgs(
     'docker',
     [
       'run',
-      '-it',
-      '--sig-proxy=false',
-      '--detach-keys=ctrl-c',
+      if (background) ...[
+        '-d'
+      ] else ...[
+        '--sig-proxy=false',
+        '--detach-keys=ctrl-c',
+        '-it',
+      ],
       '--rm',
       '-p',
       '$publicPort:$publicPort',

--- a/lib/src/docker/run_image.dart
+++ b/lib/src/docker/run_image.dart
@@ -13,7 +13,7 @@ void runImage({String? port}) {
       '-it',
       '--rm',
       '-p',
-      '$publicPort:8080',
+      '$publicPort:$publicPort',
       '--name',
       mainProject!.name,
       '${mainProject!.name}:dev',

--- a/lib/src/util/command_runner.dart
+++ b/lib/src/util/command_runner.dart
@@ -25,7 +25,9 @@ void commandRunner(
     );
     if (!silent) print(green(successMessage));
   } catch (e) {
-    print(processProgress.lines.join('\n'));
-    exit(1);
+    if (!silent) {
+      print(processProgress.lines.join('\n'));
+      exit(1);
+    }
   }
 }

--- a/template/run_command.template.dart
+++ b/template/run_command.template.dart
@@ -18,6 +18,10 @@ class RunCommand extends Command {
       abbr: 'b',
       help: 'Call the docker build command before running',
     );
+    argParser.addFlag(
+      'background',
+      help: 'Run the app in the background',
+    );
     argParser.addOption(
       'port',
       abbr: 'p',
@@ -29,7 +33,9 @@ class RunCommand extends Command {
   Future<void> run() async {
     checkDockerInstall();
     final withBuildCommand = argResults!['build'] as bool;
+    final background = argResults!['background'] as bool;
     final port = argResults?['port'] as String?;
+
     if (port != null) {
       final isPort = RegExp(r'^[0-9]{1,4}\$').hasMatch(port);
       if (!isPort) {
@@ -40,6 +46,6 @@ class RunCommand extends Command {
     if (withBuildCommand) {
       await BuildCommand().run();
     }
-    runImage(port: port);
+    runImage(port: port, background: background);
   }
 }

--- a/template/server.template.dart
+++ b/template/server.template.dart
@@ -19,7 +19,7 @@ void main(List<String> args) async {
   final app = Router();
   // For Google Cloud Run, we respect the PORT environment variable
   final portStr = Platform.environment['PORT'];
-  final port = int.tryParse(portStr ?? '8080');
+  final port = int.tryParse(portStr ?? '8000');
 
   if (!Directory(appDirectory).existsSync()) {
     throw "Can't serve APP_DIRECTORY $appDirectory, it doesn't exits";
@@ -43,5 +43,8 @@ void main(List<String> args) async {
   );
   if (portStr == null) {
     print('Serving at http://localhost:$port');
+    print(
+      'Note: If you used the -p --port option, the actuall port is different',
+    );
   }
 }


### PR DESCRIPTION
Running now in Foreground

Be able to run in background with `--background`
Entered port is now the same like in the container
Added warning to the `server.dart` running on print that it might differ

Adressing Issue #30 