### PR TITLE
Set CSP to reportOnly

### DIFF
--- a/template/build_command.template.dart
+++ b/template/build_command.template.dart
@@ -29,5 +29,11 @@ class BuildCommand extends Command {
     // and before building the Docker image
 
     createDockerImage();
+
+    print(
+      yellow(
+        'Warning: Update the CSP Rules in the template/middlewares.template.dart file to make the app production ready',
+      ),
+    );
   }
 }

--- a/template/middlewares.template.dart
+++ b/template/middlewares.template.dart
@@ -15,7 +15,12 @@ Middleware middlewares() {
   pipeline = pipeline.addMiddleware(
     helmet(
       options: const HelmetOptions(
-        cspOptions: ContentSecurityPolicyOptions.useDefaults(
+        // TODO: Add your own CSP options
+        cspOptions: ContentSecurityPolicyOptions.dangerouslyDisableDefaultSrc(),
+
+        // These are the CSP Rules for a default flutter web app
+        /*
+        ContentSecurityPolicyOptions.useDefaults(
           directives: {
             'script-src': [
               "'unsafe-eval'",
@@ -31,6 +36,7 @@ Middleware middlewares() {
             ],
           },
         ),
+        */
         coepOptions: CrossOriginEmbedderPolicyOptions.credentialLess,
       ),
     ),

--- a/template/middlewares.template.dart
+++ b/template/middlewares.template.dart
@@ -16,9 +16,9 @@ Middleware middlewares() {
     helmet(
       options: const HelmetOptions(
         // TODO: Add your own CSP options
-        cspOptions: ContentSecurityPolicyOptions.useDefaults(reportOnly: true),
-        /*
-        ContentSecurityPolicyOptions.useDefaults(
+        cspOptions: ContentSecurityPolicyOptions.useDefaults(
+          // TODO: Disable reportOnly in production
+          reportOnly: true,
           directives: {
             'script-src': [
               "'unsafe-eval'",
@@ -34,7 +34,7 @@ Middleware middlewares() {
             ],
           },
         ),
-        */
+
         coepOptions: CrossOriginEmbedderPolicyOptions.credentialLess,
       ),
     ),

--- a/template/middlewares.template.dart
+++ b/template/middlewares.template.dart
@@ -16,9 +16,7 @@ Middleware middlewares() {
     helmet(
       options: const HelmetOptions(
         // TODO: Add your own CSP options
-        cspOptions: ContentSecurityPolicyOptions.dangerouslyDisableDefaultSrc(),
-
-        // These are the CSP Rules for a default flutter web app
+        cspOptions: ContentSecurityPolicyOptions.useDefaults(reportOnly: true),
         /*
         ContentSecurityPolicyOptions.useDefaults(
           directives: {


### PR DESCRIPTION
Updated the CSP Rules in `middlewares.dart`to `reportOnly` so that they will be reported but not enforced.
Added a warning and todos to point out that it is not production ready in this configuration