### PR TITLE
Kill container on sigint

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ You can customize the build process in the commands/docker/build_command.dart fi
 <<your_cli>> docker run
 ```
 
+You can detach and kill the container by pressing `Ctrl + C` twice.
+
 This will run your app and makes it accessible at `localhost:8000`.
 With the `--background` flag you can run the container in the background.
 With the `-b, --build` flag you can execute the build command before running the container.
@@ -55,9 +57,6 @@ With the `-p, --port` flag you can specify the port on which the app is accessib
 The build command can choose between different environments.
 The default environment is `dev`.
 You can change the environment with the `--env` flag.
-
-You can detach from your running container with `Ctrl + P + Q` or `Ctrl + C`.
-Afterwards you can kill the container with `<<your_cli>> docker stop`.
 
 #### Stop the container
 

--- a/lib/src/docker/stop_image.dart
+++ b/lib/src/docker/stop_image.dart
@@ -2,12 +2,17 @@ import 'package:dockerize_sidekick_plugin/src/util/command_runner.dart';
 import 'package:sidekick_core/sidekick_core.dart';
 
 /// Stoping the currently running docker image
-void stopImage({bool silent = false}) {
+void stopImage({
+  bool silent = false,
+  String? mainProjectName,
+  Directory? workingDirectory,
+}) {
+  final projectName = mainProjectName ?? mainProject!.name;
   commandRunner(
     'docker',
-    ['kill', mainProject!.name],
-    workingDirectory: repository.root.directory('server'),
+    ['kill', projectName],
+    workingDirectory: workingDirectory ?? repository.root.directory('server'),
     silent: silent,
-    successMessage: 'Stopped app: ${mainProject!.name}',
+    successMessage: 'Stopped app: $projectName',
   );
 }

--- a/template/run_command.template.dart
+++ b/template/run_command.template.dart
@@ -47,6 +47,9 @@ class RunCommand extends Command {
     final background = argResults!['background'] as bool;
     final port = argResults?['port'] as String?;
 
+    final mainProjectName = mainProject!.name;
+    final workingDir = repository.root.directory('server');
+
     /// Stoping all other running containers from the project
     stopImage(silent: true);
 
@@ -72,5 +75,9 @@ class RunCommand extends Command {
       port: port,
       background: background,
     );
+    ProcessSignal.sigint.watch().listen((signal) {
+      stopImage(mainProjectName: mainProjectName, workingDirectory: workingDir);
+      exit(0);
+    });
   }
 }


### PR DESCRIPTION
we are now able to kill the process on sigint(ctrl+c) but we have to press it twice because the press is the detachment from the container