### PR TITLE
Use dockerx for builds

### DIFF
--- a/lib/src/docker/create_image.dart
+++ b/lib/src/docker/create_image.dart
@@ -8,7 +8,7 @@ void createDockerImage(String environmentName) {
   );
   commandRunner(
     'docker',
-    ['build', '-t', '${mainProject!.name}:$environmentName', '.'],
+    ['buildx', 'build', '-t', '${mainProject!.name}:$environmentName', '.'],
     workingDirectory: repository.root.directory('server'),
     successMessage: 'Created image ${mainProject!.name}:$environmentName',
   );


### PR DESCRIPTION
Using dockerx for builds because it has more advanced caching reasons so future build will be faster