### PR TITLE
Add option to only build docker-container

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ To run this locally you need [Docker](https://docs.docker.com/get-docker/) insta
 <<your_cli>> docker build
 ```
 
+With the `--docker-only` flag you just build the docker container without the flutter build command.
+
 The build command can choose between different environments.
 The default environment is `dev`.
 You can change the environment with the `--env` flag.
@@ -51,8 +53,9 @@ You can detach and kill the container by pressing `Ctrl + C` twice.
 
 This will run your app and makes it accessible at `localhost:8000`.
 With the `--background` flag you can run the container in the background.
-With the `-b, --build` flag you can execute the build command before running the container.
+With the `-b, --build-all` flag you can execute the build command before running the container.
 With the `-p, --port` flag you can specify the port on which the app is accessible.
+With the `--build-docker` flag you just build the docker container without the flutter build command.
 
 The build command can choose between different environments.
 The default environment is `dev`.

--- a/template/build_command.template.dart
+++ b/template/build_command.template.dart
@@ -21,6 +21,11 @@ class BuildCommand extends Command {
       allowed: _environments.map((it) => it.name),
       help: 'The environment to build the docker image for',
     );
+    argParser.addFlag(
+      'docker-only',
+      abbr: 'd',
+      help: 'Builds only the docker image',
+    );
   }
 
   @override
@@ -29,24 +34,28 @@ class BuildCommand extends Command {
     final Stopwatch flutterBuildStopwatch = Stopwatch();
     final Stopwatch dockerBuildStopwatch = Stopwatch();
     final String environmentName = argResults!['env'] as String? ?? 'dev';
+    final bool shouldOnlyBuildDocker =
+        argResults!['docker-only'] as bool? ?? false;
     final DockerizeEnvironment env =
         _environments.firstWhere((it) => it.name == environmentName);
     checkDockerInstall();
 
-    // You can insert your own logic here before building the Flutter app
+    if (!shouldOnlyBuildDocker) {
+      // You can insert your own logic here before building the Flutter app
 
-    flutterBuildStopwatch.start();
-    flutter(
-      // You can change any build arguments here like --release
-      // Check out `flutter build web --help` for more information
-      ['build', 'web'],
-      workingDirectory: mainProject!.root,
-    );
-    flutterBuildStopwatch.stop();
+      flutterBuildStopwatch.start();
+      flutter(
+        // You can change any build arguments here like --release
+        // Check out `flutter build web --help` for more information
+        ['build', 'web'],
+        workingDirectory: mainProject!.root,
+      );
+      flutterBuildStopwatch.stop();
 
-    // You can insert your own logic here after building the Flutter app
+      // You can insert your own logic here after building the Flutter app
 
-    moveToServerDirectory();
+      moveToServerDirectory();
+    }
 
     // You can disable the hashScripts() function if you don't want to use CSP
     // You can change the hashType to sha384 or sha512 if you want
@@ -76,12 +85,14 @@ class BuildCommand extends Command {
     print(
       '- Finished Dockerize build in ${allStopwatch.elapsedMilliseconds}ms',
     );
-    print(
-      '  - Flutter build took ${flutterBuildStopwatch.elapsedMilliseconds}ms',
-    );
-    print(
-      '  - Docker build took ${dockerBuildStopwatch.elapsedMilliseconds}ms',
-    );
+    if (!shouldOnlyBuildDocker) {
+      print(
+        '  - Flutter build took ${flutterBuildStopwatch.elapsedMilliseconds}ms',
+      );
+      print(
+        '  - Docker build took ${dockerBuildStopwatch.elapsedMilliseconds}ms',
+      );
+    }
 
     // TODO: Remove this warning after updating the CSP rules in the template/middlewares.template.dart file
     print(

--- a/template/run_command.template.dart
+++ b/template/run_command.template.dart
@@ -17,9 +17,13 @@ class RunCommand extends Command {
 
   RunCommand() {
     argParser.addFlag(
-      'build',
+      'build-all',
       abbr: 'b',
       help: 'Call the docker build command before running',
+    );
+    argParser.addFlag(
+      'build-container',
+      help: 'Builds the docker container before running',
     );
     argParser.addFlag(
       'background',
@@ -43,7 +47,8 @@ class RunCommand extends Command {
     final DockerizeEnvironment env =
         _environments.firstWhere((it) => it.name == environmentName);
     checkDockerInstall();
-    final withBuildCommand = argResults!['build'] as bool;
+    final withBuildAll = argResults!['build-all'] as bool;
+    final withBuildContainer = argResults!['build-container'] as bool;
     final background = argResults!['background'] as bool;
     final port = argResults?['port'] as String?;
 
@@ -60,11 +65,12 @@ class RunCommand extends Command {
         exit(1);
       }
     }
-    if (withBuildCommand) {
+    if (withBuildAll || withBuildContainer) {
       final process = dcli.startFromArgs(Repository.requiredEntryPoint.path, [
         'docker',
         'build',
         '--env=$environmentName',
+        if (withBuildContainer) '--docker-only',
       ]);
       process.exitCode == 0
           ? print(green('Build successful'))


### PR DESCRIPTION
This PR adresses #56 
The build command now supports building only the docker container.
You can do this with the `--docker-only` flag.
`<<your_cli>> docker build --docker-only`

The run command support this too.
You can do this with `--build-container`
`<<your_cli>> docker run --build-container --env=dev`

If you want to run and build the flutter app and the container you can do this with:
`<<your_cli>> docker run --build-all --env=dev`