### PR TITLE
Append to version file instead of overwrite

### DIFF
--- a/lib/src/util/version_file.dart
+++ b/lib/src/util/version_file.dart
@@ -7,10 +7,8 @@ void createVersionFile({Map<String, dynamic>? entries}) {
     "created_at": DateTime.now().toIso8601String(),
     ...entries ?? {},
   };
-  final middlewareFile = repository.root.file('server/www/version.json');
-  if (!middlewareFile.existsSync()) {
-    middlewareFile.createSync(recursive: true);
-  }
-
-  middlewareFile.writeAsStringSync(jsonEncode(content));
+  final versionFile = repository.root.file('server/www/version.json');
+  final versionContent = jsonDecode(versionFile.readAsStringSync()) as Map;
+  versionContent.addAll(content);
+  versionFile.writeAsStringSync(jsonEncode(versionContent));
 }


### PR DESCRIPTION
This PR resolves #64 
We are now appending to the existing version.json instead of overwriting.

Before:
```json
{"created_at":"2023-01-09T15:01:39.382770","environment":"dev"}
```

After:
```json
{"app_name":"bam","version":"1.0.0","build_number":"1","package_name":"bam","created_at":"2023-01-09T15:01:39.382770","environment":"dev"}
```
