### PR TITLE
Loose Lint Constraints

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   watcher: ^1.0.2
 
 dev_dependencies:
-  lint: ^2.0.0
+  lint: '>=1.7.0 <2.0.0'
   mocktail: ^0.3.0
   sidekick_plugin_installer: ^0.2.1
   test: ^1.22.0

--- a/template/pubspec.template.yaml
+++ b/template/pubspec.template.yaml
@@ -7,7 +7,7 @@ publish_to: 'none'
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.15.0 <3.0.0"
+  sdk: ">=2.16.0 <3.0.0"
 
 dependencies:
   shelf: ^1.4.0
@@ -16,4 +16,4 @@ dependencies:
   shelf_static: ^1.1.0
 
 dev_dependencies: 
-  lint: ^2.0.0
+  lint: '>=1.7.0 <2.0.0'

--- a/template/pubspec.yaml
+++ b/template/pubspec.yaml
@@ -5,7 +5,7 @@ publish_to: 'none'
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.18.0 <3.0.0"
+  sdk: ">=2.16.0 <3.0.0"
 
 dependencies:
   dcli: ^1.36.0
@@ -15,7 +15,7 @@ dependencies:
   shelf_helmet: ^1.1.0
   shelf_router: ^1.1.3
   shelf_static: ^1.1.0
-  sidekick_core: ^0.13.0
+  sidekick_core: ^0.15.1
 
 dev_dependencies: 
-  lint: ^2.0.0
+  lint: '>=1.7.0 <2.0.0'


### PR DESCRIPTION
Loosened the Constraints for `lint` so that dockerize can be installed with `Dart: 2.14`