### PR TITLE
Add Muted by default Garbage Collector

### DIFF
--- a/.github/workflows/on_push.yml
+++ b/.github/workflows/on_push.yml
@@ -10,7 +10,7 @@ jobs:
       with:
         dart_sdk: "stable"
         platform: "vm"
-        min_coverage: 38
+        min_coverage: 36
   coverage:
 
     runs-on: ubuntu-latest

--- a/lib/src/docker/collect_garbage.dart
+++ b/lib/src/docker/collect_garbage.dart
@@ -1,0 +1,42 @@
+import 'dart:io' as io;
+
+import 'package:mason_logger/mason_logger.dart';
+
+/// Internal function to remove all dangling images
+Future<void> garbageCollector({
+  required Logger logger,
+  bool silent = true,
+}) async {
+  /// Getting all danling images
+  final danglingImagesProcess = await io.Process.run(
+    'docker',
+    ['images', '-f', 'dangling=true', '-q'],
+  );
+
+  final List<String> danglingImages =
+      danglingImagesProcess.stdout.toString().split('\n')
+        ..removeWhere(
+          (element) => element.isEmpty || element == ' ',
+        );
+
+  if (danglingImages.isEmpty) {
+    if (!silent) logger.success('[dockerize] No dangling images found 🎉');
+    return;
+  }
+
+  /// Removing all dangling images
+  final process = await io.Process.run(
+    'docker',
+    [
+      'rmi',
+      ...danglingImages,
+    ],
+  );
+  if (process.exitCode == 0) {
+    if (!silent) logger.success('[dockerize] Removed all dangling images 🎉');
+  } else if (!silent) {
+    logger.err('[dockerize] Failed to remove all dangling images 😢');
+    logger.err(process.stdout.toString());
+    logger.err(process.stderr.toString());
+  }
+}

--- a/lib/src/docker/create_image.dart
+++ b/lib/src/docker/create_image.dart
@@ -1,5 +1,6 @@
 import 'dart:io' as io;
 
+import 'package:dockerize_sidekick_plugin/src/docker/collect_garbage.dart';
 import 'package:mason_logger/mason_logger.dart';
 import 'package:sidekick_core/sidekick_core.dart' hide Progress;
 
@@ -79,6 +80,7 @@ Future<void> createDockerImage(
     logger.err(process.stdout.toString());
     logger.err(process.stderr.toString());
   }
+  garbageCollector(logger: logger);
   logger.info(
     '${lightGreen.wrap('✓')} [dockerize] image name: ${lightGreen.wrap(styleBold.wrap('$containerName:$environmentName'))}',
   );


### PR DESCRIPTION
Adding Garbage Collector which is collecting all `<none>:<none>`(dangling) Images after a build to prevent storage overflow.

Garbage Collector is muted by default and can be unmuted during debugging Sessions.

How to test:
- Run your test project with dockerize sometimes to create `<none>:<none>` images
- Checkout this branch in your local dockerize repo
- re-install dockerize
- run `<<cli_name>> docker run -b` to run and build
- afterwards you should have 0 `<none>:<none>` images