### PR TITLE
Allow injecting docker --build-arg

### DIFF
--- a/lib/src/docker/create_image.dart
+++ b/lib/src/docker/create_image.dart
@@ -5,6 +5,8 @@ import 'package:mason_logger/mason_logger.dart';
 import 'package:sidekick_core/sidekick_core.dart' hide Progress;
 
 /// Creates a docker image
+///
+/// Use [buildArgs] to pass additional arguments to the docker build command.
 Future<void> createDockerImage(
   String environmentName, {
   String? mainProjectName,
@@ -13,6 +15,7 @@ Future<void> createDockerImage(
   required Logger logger,
   bool buildScripts = true,
   bool buildFlutter = true,
+  List<String> buildArgs = const [],
 }) async {
   final containerName = mainProjectName ?? mainProject!.name;
   if (buildFlutter) {
@@ -68,6 +71,7 @@ Future<void> createDockerImage(
       'buildx',
       'build',
       '-t',
+      ...buildArgs,
       '$containerName:$environmentName',
       '.',
     ],

--- a/lib/src/docker/create_image.dart
+++ b/lib/src/docker/create_image.dart
@@ -70,8 +70,8 @@ Future<void> createDockerImage(
     [
       'buildx',
       'build',
-      '-t',
       ...buildArgs,
+      '-t',
       '$containerName:$environmentName',
       '.',
     ],

--- a/lib/src/docker/run_image.dart
+++ b/lib/src/docker/run_image.dart
@@ -17,6 +17,7 @@ Future<void> runImage({
   required DartPackage? mainProject,
   required bool withoutHotReload,
   String? port,
+  List<String> buildArgs = const [],
 }) async {
   final mainProjectName = mainProject?.name ?? 'app';
   final projectRoot = SidekickContext.projectRoot;
@@ -137,6 +138,7 @@ Future<void> runImage({
           buildFlutter: reloadAll,
           workingDirectoryPath:
               SidekickContext.projectRoot.directory('server').path,
+          buildArgs: buildArgs,
         );
         final progress = logger.progress('[dockerize] Starting image...');
         runImage();


### PR DESCRIPTION
Usage:


```dart
await createDockerImage(
  //...
  buildArgs: ['--build-arg', 'SHIELD_PASSWORD=$password'],
);
```

This can then be used inside the docker file:

```dockerfile
FROM dart:stable AS build

ARG SHIELD_PASSWORD

RUN dart compile exe \
  --define=SHIELD_PASSWORD=$SHIELD_PASSWORD \
  -o bin/server \
  bin/server.dart
```