### PR TITLE
Improve Build arg api

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,11 @@ Here are the official guides for the biggest cloud providers:
 By default we are generating a very simple way of handling different environments.
 You can change the environments in the `commands/docker/environment.dart` file.
 
+#### Build args
+
+You can easily pass arguments to your docker file.
+To do this you can just pass the build args into the `createDockerImage` function in the `commands/docker/build_image_command.dart` file.
+
 #### Script hashes
 
 By default we are generating script hashes for each script tag in your index.html file.

--- a/lib/src/docker/create_image.dart
+++ b/lib/src/docker/create_image.dart
@@ -15,6 +15,9 @@ Future<void> createDockerImage(
   required Logger logger,
   bool buildScripts = true,
   bool buildFlutter = true,
+
+  /// Build arguments to pass into the docker command
+  /// `--build-arg` will be added to each argument automatically
   List<String> buildArgs = const [],
 }) async {
   final containerName = mainProjectName ?? mainProject!.name;
@@ -70,7 +73,7 @@ Future<void> createDockerImage(
     [
       'buildx',
       'build',
-      ...buildArgs,
+      for (final buildArg in buildArgs) ...['--build-arg', buildArg],
       '-t',
       '$containerName:$environmentName',
       '.',


### PR DESCRIPTION
Improved the build arg api to prevent common user errors like missing  `--build-arg` for multiple arguments.

Now adding `--build-arg` automatically before each passed build-arg string.