### PR TITLE
bump sidekick_core version + loosen up some dependencies

### DIFF
--- a/.github/workflows/on_push.yml
+++ b/.github/workflows/on_push.yml
@@ -8,7 +8,7 @@ jobs:
   build:
       uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/dart_package.yml@v1
       with:
-        dart_sdk: "stable"
+        dart_sdk: "2.19.0"
         platform: "vm"
         min_coverage: 0
   coverage:
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     
     container:
-      image:  dart:2.18
+      image:  dart:2.19
     
     steps:
     - uses: actions/checkout@v2

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   html: ^0.15.1
   mason_logger: ^0.2.3
   path: ^1.8.3
-  sidekick_core: ^1.0.1
+  sidekick_core: ">=1.3.0 <2.0.0"
   stream_transform: ^2.1.0
   watcher: ^1.0.2
 

--- a/template/pubspec.template.yaml
+++ b/template/pubspec.template.yaml
@@ -10,7 +10,7 @@ environment:
   sdk: ">=2.16.0 <3.0.0"
 
 dependencies:
-  dockerize_sidekick_plugin: ^0.5.0
+  dockerize_sidekick_plugin: ">=0.5.0 <1.0.0"
   shelf: ^1.4.0
   shelf_helmet: ^1.1.0
   shelf_router: ^1.1.3

--- a/template/pubspec.template.yaml
+++ b/template/pubspec.template.yaml
@@ -1,7 +1,6 @@
 name: dockerize_server
 description: A new Dockerized Flutter App
 
-
 publish_to: 'none'
 
 version: 1.0.0+1

--- a/template/pubspec.yaml
+++ b/template/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   shelf_helmet: ^1.1.0
   shelf_router: ^1.1.3
   shelf_static: ^1.1.0
-  sidekick_core: ^1.0.1
+  sidekick_core: ">=1.3.0 <2.0.0"
 
 dev_dependencies: 
   lint: '>=1.7.0 <2.0.0'


### PR DESCRIPTION
### What does this PR change?
- [x] Bump sidekick_core version to be ready for the sidekick dart 3.0.0 release

read this issue for more:
https://github.com/phntmxyz/sidekick/issues/227#issuecomment-1561170709

### How to test this feature?
* If the CI is running everything is fine 
